### PR TITLE
Create Qwik Badge component

### DIFF
--- a/apps/qwik-app/src/components/ui/badge/badge.stories.tsx
+++ b/apps/qwik-app/src/components/ui/badge/badge.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from 'storybook-framework-qwik'
+import Badge from './index'
+
+const meta: Meta<typeof Badge> = {
+  title: 'UI/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    appearance: {
+      control: 'select',
+      options: ['pink', 'green']
+    }
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof Badge>
+
+export const PinkBadge: Story = {
+  args: {
+    appearance: 'pink',
+  },
+  render: (args) => (
+    <Badge {...args}>
+      51% OFF
+    </Badge>
+  ),
+}
+
+export const GreenBadge: Story = {
+  args: {
+    appearance: 'green',
+  },
+  render: (args) => (
+    <Badge {...args}>
+      10% OFF
+    </Badge>
+  ),
+}

--- a/apps/qwik-app/src/components/ui/badge/index.tsx
+++ b/apps/qwik-app/src/components/ui/badge/index.tsx
@@ -1,0 +1,35 @@
+import { component$, Slot } from '@builder.io/qwik'
+import { tv, type VariantProps } from 'tailwind-variants/lite'
+
+const badgeVariants = tv({
+  base: 'inline-flex items-center justify-center rounded-[16px] px-4 py-2 text-center font-medium text-sm',
+  variants: {
+    appearance: {
+      pink: 'bg-[#FFC0CB] text-gray-900',
+      green: 'bg-[#90EE90] text-gray-900'
+    }
+  }
+})
+
+interface BadgeProps extends VariantProps<typeof badgeVariants> {
+  appearance: 'pink' | 'green'
+  [key: string]: any
+}
+
+export default component$<BadgeProps>(({
+  appearance,
+  class: className,
+  ...restProps
+}: Readonly<BadgeProps>) => {
+  return (
+    <span
+      class={badgeVariants({
+        appearance,
+        class: className
+      })}
+      {...restProps}
+    >
+      <Slot />
+    </span>
+  )
+})


### PR DESCRIPTION
- Add Badge component with appearance variants (pink/green)
- Implement using tailwind-variants for type-safe styling
- Include Storybook stories for both pink and green badges
- Use pill shape with 16px border radius and proper padding