### PR TITLE
Create Input component system with wrapper

### DIFF
--- a/apps/qwik-app/src/components/ui/input/index.tsx
+++ b/apps/qwik-app/src/components/ui/input/index.tsx
@@ -1,0 +1,88 @@
+import { component$, Slot, useSignal, useContextProvider, useContext, createContextId, $, type Signal, type QRL } from '@builder.io/qwik'
+import { tv, type VariantProps } from 'tailwind-variants/lite'
+
+interface InputContextState {
+  isFocused: Signal<boolean>
+  onFocus: QRL<() => void>
+  onBlur: QRL<() => void>
+}
+
+const InputContext = createContextId<InputContextState>('input-context')
+
+const wrapperVariants = tv({
+  base: 'flex items-center rounded-lg transition-all',
+  variants: {
+    focused: {
+      true: 'border-2 border-[#2563EB]',
+      false: 'border border-[#E5E5E5]'
+    },
+    fullWidth: {
+      true: 'w-full',
+      false: 'w-auto'
+    }
+  },
+  defaultVariants: {
+    focused: false,
+    fullWidth: false
+  }
+})
+
+interface InputWrapperProps extends Omit<VariantProps<typeof wrapperVariants>, 'focused'> {
+  class?: string
+}
+
+export const InputWrapper = component$<InputWrapperProps>(({ fullWidth, class: className }) => {
+  const isFocused = useSignal(false)
+
+  const contextValue: InputContextState = {
+    isFocused,
+    onFocus: $(() => {
+      isFocused.value = true
+    }),
+    onBlur: $(() => {
+      isFocused.value = false
+    })
+  }
+
+  useContextProvider(InputContext, contextValue)
+
+  return (
+    <div
+      class={wrapperVariants({
+        focused: isFocused.value,
+        fullWidth,
+        class: className
+      })}
+    >
+      <Slot />
+    </div>
+  )
+})
+
+interface InputProps {
+  placeholder?: string
+  class?: string
+  type?: string
+  value?: string
+  name?: string
+  id?: string
+  disabled?: boolean
+  readonly?: boolean
+  required?: boolean
+  [key: string]: any
+}
+
+export default component$<InputProps>(({ placeholder, class: className, ...restProps }) => {
+  const context = useContext(InputContext)
+
+  return (
+    <input
+      type="text"
+      placeholder={placeholder}
+      class={`flex-1 px-4 py-3 outline-none bg-transparent text-sm ${className || ''}`}
+      onFocus$={context.onFocus}
+      onBlur$={context.onBlur}
+      {...restProps}
+    />
+  )
+})

--- a/apps/qwik-app/src/components/ui/input/input.stories.tsx
+++ b/apps/qwik-app/src/components/ui/input/input.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from 'storybook-framework-qwik'
+import Input, { InputWrapper } from './index'
+
+const meta: Meta<typeof Input> = {
+  title: 'UI/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof Input>
+
+export const NormalInput: Story = {
+  render: () => (
+    <div class="w-80">
+      <InputWrapper fullWidth>
+        <Input placeholder="Your Name" />
+      </InputWrapper>
+    </div>
+  ),
+}
+
+export const SearchInput: Story = {
+  render: () => (
+    <div class="w-80">
+      <InputWrapper fullWidth>
+        <Input placeholder="Search..." />
+        <svg
+          class="w-5 h-5 mr-3 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+      </InputWrapper>
+    </div>
+  ),
+}


### PR DESCRIPTION
Create reusable Input component with focus state management through InputWrapper container. InputWrapper detects child Input focus state via Qwik context and applies appropriate border styling. Supports optional fullWidth prop and any JSX adornments positioned at end.