### PR TITLE
Fix most wanted section image sizing

### DIFF
--- a/apps/qwik-app/src/components/sections/most-wanted/index.tsx
+++ b/apps/qwik-app/src/components/sections/most-wanted/index.tsx
@@ -59,9 +59,9 @@ export default component$<MostWantedProps>(({ title, products }) => {
                   alt={product.image.alt}
                   width="180"
                   height="180"
-                  class="max-w-full max-h-full object-contain drop-shadow-sm"
+                  class="w-full h-full object-cover"
                   pictureProps={{
-                    class: "w-full h-full flex items-center justify-center"
+                    class: "w-full h-full"
                   }}
                 />
               </div>


### PR DESCRIPTION
Updated images to use w-full h-full with object-cover instead of max-w-full max-h-full with object-contain. This removes the visible colored background around product images.